### PR TITLE
Update VRMLParser.General.cs

### DIFF
--- a/VRMLParser/VRMLParser.General.cs
+++ b/VRMLParser/VRMLParser.General.cs
@@ -550,7 +550,7 @@ namespace Free.FileFormats.VRML
 				RouteDeclaration route=new RouteDeclaration();
 				route.EventOut=eventOutId;
 				route.Target=instances[nodeNameIdIn];
-				route.EventOut=eventInId;
+				route.EventIn=eventInId;
 				instances[nodeNameIdOut].Routes.Add(route);
 			}
 		}


### PR DESCRIPTION
Bug fix at line 553. EventOut was assigned twice and EventIn was not assigned.